### PR TITLE
feat: Improve support for unprivileged hosts (including LXC)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get -y upgrade \
         curl \
         cpio \
         wget \
+        fakeroot \
         fdisk \
         unzip \
         socat \


### PR DESCRIPTION
* Add fakeroot to extract the dsm system without elevated permissions
* Remove obsolete docker variable "DEV" used to exclude extraction of device nodes