### PR TITLE
fix: Splits $USER_PORTS correctly by commas

### DIFF
--- a/src/network.sh
+++ b/src/network.sh
@@ -112,7 +112,7 @@ getUserPorts() {
 
   [ -z "$list" ] && list="$ssh,$dsm" || list+=",$ssh,$dsm"
 
-  list="${list/,/ }"
+  list="${list//,/ }"
   list="${list## }"
   list="${list%% }"
 


### PR DESCRIPTION
According to https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion

> ${parameter/pattern/string}
> ${parameter//pattern/string}
> ${parameter/#pattern/string}
> ${parameter/%pattern/string}
>
> In the first form above, only the first match is replaced.
> If there are two slashes separating parameter and pattern (the second form above), all matches of pattern are replaced with string.

current implementation only replaces the very first comma and leads to error when $USER_PORTS was set.

```
❯ Starting Virtual DSM for Docker v7.16...                                                                                                                                                    
❯ For support visit https://github.com/vdsm/virtual-dsm                                                                                                                                       
❯ CPU: Intel Xeon Silver 4214R CPU | RAM: 3/8 GB | DISK: 12 GB (ext4) | HOST: 4.4.0-210...                                                                                                    
                                                                                                                                                                                              
❯ Warning: your container IP starts with 172.17.* which will cause conflicts when you install the Container Manager package inside DSM!                                                       
❯ Warning: unexpected clocksource: kvm-clock
❯ Booting Virtual DSM using QEMU v9.0.2...
❯ ERROR: qemu-system-x86_64: -netdev user,id=hostnet0,host=20.20.20.1,net=20.20.20.0/24,dhcpstart=20.20.20.21,hostname=VirtualDSM,hostfwd=tcp::123-20.20.20.21:123,hostfwd=tcp::321,,22,5000-2
0.20.20.21:321,,22,5000: Invalid parameter '22'
 
```

We should use double slash instead to replace all commas.