### PR TITLE
feat: add UDP support to USER_PORTS

### DIFF
--- a/src/network.sh
+++ b/src/network.sh
@@ -152,7 +152,18 @@ getUserPorts() {
   list="${list%% }"
 
   for port in $list; do
-    args+="hostfwd=tcp::$port-$VM_NET_IP:$port,"
+    proto="tcp"
+    num="$port"
+
+    if [[ "$port" == */udp ]]; then
+      proto="udp"
+      num="${port%/udp}"
+    elif [[ "$port" == */tcp ]]; then
+      proto="tcp"
+      num="${port%/tcp}"
+    fi
+
+    args+="hostfwd=$proto::$num-$VM_NET_IP:$num,"
   done
 
   echo "${args%?}"


### PR DESCRIPTION
Allow USER_PORTS entries in the form PORT or PORT/PROTO (tcp or udp). When the protocol is omitted, TCP is assumed for backward compatibility. This enables forwarding of UDP services when running the container in user‑mode networking.