### PR TITLE
fix: Parse quoted DHCP and NETWORK values consistently

### DIFF
--- a/src/check.sh
+++ b/src/check.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+cd /run
+. utils.sh      # Load functions
+
 : "${DHCP:="N"}"
 : "${NETWORK:="Y"}"
 
 [ -f "/run/shm/qemu.end" ] && echo "QEMU is shutting down..." && exit 1
 [ ! -s "/run/shm/qemu.pid" ] && echo "QEMU is not running yet..." && exit 0
-[[ "$NETWORK" == [Nn]* ]] && echo "Networking is disabled." && exit 0
+disabled "$NETWORK" && echo "Networking is disabled." && exit 0
 
 file="/run/shm/dsm.url"
 address="/run/shm/qemu.ip"
@@ -18,7 +21,7 @@ location=$(<"$file")
 
 if ! curl -m 20 -ILfSs "http://$location/" > /dev/null; then
 
-  if [[ "$DHCP" == [Yy1]* ]]; then
+  if enabled "$DHCP"; then
     ip=$(<"$address")
     echo "Failed to reach DSM at http://$location"
   else

--- a/src/print.sh
+++ b/src/print.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+cd /run
+. utils.sh      # Load functions
+
 : "${DHCP:="N"}"
 : "${NETWORK:="Y"}"
 
-[[ "$NETWORK" == [Nn]* ]] && exit 0
+disabled "$NETWORK" && exit 0
 
 info () { printf "%b%s%b" "\E[1;34m❯ \E[1;36m" "$1" "\E[0m\n" >&2; }
 error () { printf "%b%s%b" "\E[1;31m❯ " "ERROR: $1" "\E[0m\n" >&2; }
@@ -66,7 +69,7 @@ done
 
 location=$(<"$file")
 
-if [[ "$DHCP" == [Yy1]* ]]; then
+if enabled "$DHCP"; then
 
   msg="http://$location"
   title="<title>Virtual DSM</title>"

--- a/src/print.sh
+++ b/src/print.sh
@@ -13,7 +13,7 @@ info () { printf "%b%s%b" "\E[1;34m❯ \E[1;36m" "$1" "\E[0m\n" >&2; }
 error () { printf "%b%s%b" "\E[1;31m❯ " "ERROR: $1" "\E[0m\n" >&2; }
 
 file="/run/shm/dsm.url"
-info="/run/shm/msg.html"
+msgs="/run/shm/msg.html"
 driver="/run/shm/qemu.nic"
 page="/run/shm/index.html"
 address="/run/shm/qemu.ip"
@@ -25,8 +25,7 @@ resp_err="Guest returned an invalid response:"
 curl_err="Failed to connect to guest: curl error"
 jq_err="Failed to parse response from guest: jq error"
 
-while [ ! -s  "$file" ]
-do
+while [ ! -s "$file" ]; do
 
   # Check if not shutting down
   [ -f "$shutdown" ] && exit 1
@@ -46,7 +45,7 @@ do
   (( rc != 0 )) && error "$jq_err $rc ( $json )" && continue
   [[ "$result" == "null" ]] && error "$resp_err $json" && continue
 
-  if [[ "$result" != "success" ]] ; then
+  if [[ "$result" != "success" ]]; then
     { msg=$(echo "$json" | jq -r '.message'); rc=$?; } || :
     error "Guest replied $result: $msg" && continue
   fi
@@ -61,7 +60,7 @@ do
   [[ "$ip" == "null" ]] && error "$resp_err $json" && continue
 
   [ -z "$ip" ] && continue
-  echo "$ip:$port" > $file
+  echo "$ip:$port" > "$file"
 
 done
 
@@ -84,7 +83,7 @@ if enabled "$DHCP"; then
   HTML="${HTML/\[5\]/}"
 
   echo "$HTML" > "$page"
-  echo "$body" > "$info"
+  echo "$body" > "$msgs"
 
 else
 


### PR DESCRIPTION
## Problem

When an environment variable carries literal quotes — e.g. the compose list syntax `- DHCP="Y"`, which passes the quote characters through into the container — virtual-dsm parses it inconsistently:

- `network.sh` uses `enabled()` from `utils.sh`, which strips quotes, so DHCP mode **is** activated (the macvtap interface is created and the VM boots on the LAN).
- `print.sh` (spawned by host.bin) and `check.sh` (the HEALTHCHECK entrypoint) run as standalone processes and used raw `[[ "$DHCP" == [Yy1]* ]]` comparisons, which do not match `"Y"`, so they took the non-DHCP branch.

As a result the web page on port 5000 stays on "Booting DSM instance" forever (the redirect page is never generated) and the console prints the container IP instead of the VM's DHCP address. The healthcheck failure hint also picks the wrong IP.

## Fix

Source `utils.sh` in both standalone scripts (same pattern as `entry.sh`) and use `enabled "$DHCP"` / `disabled "$NETWORK"` instead of raw pattern matches. `disabled "$NETWORK"` mirrors the authoritative check already used in `network.sh`, so mode values like `slirp`/`passt` are unaffected.

## Verification

- `bash -n` passes on both scripts; no other raw `[Yy1]*`/`[Nn]*` comparisons remain in the repo.
- Reproduced in a live container whose `DHCP` variable held the literal 3-character value `"Y"`: the patched `print.sh` now takes the DHCP branch, prints the VM's real DHCP address and generates the redirect page; the patched `check.sh` reports `Healthcheck OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)